### PR TITLE
feat: Increase logo size for better visibility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -225,8 +225,8 @@ export default function OncoPathApp() {
     <Image
       src="/vector_oncopath_logo.png"
       alt="OncoPath Logo"
-      width={32}
-      height={32}
+      width={48}
+      height={48}
       className="mr-2"
     />
     <h1 className="text-3xl font-bold text-white">OncoPath</h1>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -40,8 +40,8 @@ export function Navigation({ onReset, currentState }: NavigationProps) {
                 src="/vector_oncopath_logo.png"
                 alt="Logo"
                 className="cursor-pointer"
-                width={30}
-                height={30}
+                width={48}
+                height={48}
                 onClick={() => {
                   if (window.location.pathname === "/") {
                     window.location.reload()


### PR DESCRIPTION
Increased the logo dimensions in the navigation bar and on the main page (upload state) from ~30px to 48px.

This change aims to make the logo more prominent as requested, while maintaining a clean and minimalist design.